### PR TITLE
Bad suggested value for RemoteAccessCIDR

### DIFF
--- a/templates/cloudbees-core-existing-vpc.template.yaml
+++ b/templates/cloudbees-core-existing-vpc.template.yaml
@@ -109,7 +109,7 @@ Parameters:
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
     Description:
       The CIDR IP range that is permitted to access the bastion host. We recommend
-      that you set this value to a trusted IP range. Setting this parameter to 0.0.0/0 
+      that you set this value to a trusted IP range. Setting this parameter to 0.0.0.0/0 
       will open SSH access to the bastion host from any source address.
     Type: String
   AdditionalEKSAdminArns:

--- a/templates/cloudbees-core-master.template.yaml
+++ b/templates/cloudbees-core-master.template.yaml
@@ -111,7 +111,7 @@ Parameters:
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
     Description:
       The CIDR IP range that is permitted to access the bastion host. We recommend
-      that you set this value to a trusted IP range. Setting this parameter to 0.0.0/0 
+      that you set this value to a trusted IP range. Setting this parameter to 0.0.0.0/0 
       will open SSH access to the bastion host from any source address.
     Type: String
   AdditionalEKSAdminArns:


### PR DESCRIPTION
*Description of changes:*

The quickstart suggesting using an IP range that looks to be syntactically malformed, by its own documentation.

@schottsfired

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
