### PR TITLE
fix: OPTIONAL parameter LambdaZipsBucketName used unconditionally throughout cloudbees-core-existing-cluster.template.yaml

### DIFF
--- a/templates/cloudbees-core-existing-cluster.template.yaml
+++ b/templates/cloudbees-core-existing-cluster.template.yaml
@@ -303,8 +303,8 @@ Resources:
               - Effect: Allow
                 Action: s3:*
                 Resource:
-                  - !Sub 'arn:aws:s3:::${LambdaZipsBucketName}/*'
-                  - !Sub 'arn:aws:s3:::${LambdaZipsBucketName}'
+                  - !If [ CreateLambdaZipsBucket, !Sub 'arn:aws:s3:::${LambdaZipsBucket}/*', !Sub 'arn:aws:s3:::${LambdaZipsBucketName}/*' ]
+                  - !If [ CreateLambdaZipsBucket, !Sub 'arn:aws:s3:::${LambdaZipsBucket}', !Sub 'arn:aws:s3:::${LambdaZipsBucketName}' ]
   CopyZipsRole:
     Type: AWS::IAM::Role
     Properties:
@@ -329,7 +329,7 @@ Resources:
                 Action:
                   - s3:PutObject
                   - s3:DeleteObject
-                Resource: !Sub 'arn:aws:s3:::${LambdaZipsBucketName}/${QSS3KeyPrefix}*'
+                Resource: !If [ CreateLambdaZipsBucket, !Sub 'arn:aws:s3:::${LambdaZipsBucket}/${QSS3KeyPrefix}*', !Sub 'arn:aws:s3:::${LambdaZipsBucketName}/${QSS3KeyPrefix}*' ]
   ManifestRole:
     Type: "AWS::IAM::Role"
     Properties:

--- a/templates/cloudbees-core-existing-cluster.template.yaml
+++ b/templates/cloudbees-core-existing-cluster.template.yaml
@@ -110,7 +110,7 @@ Resources:
     Type: Custom::CopyZips
     Properties:
       ServiceToken: !GetAtt 'CopyZipsFunction.Arn'
-      DestBucket: !Ref LambdaZipsBucketName
+      DestBucket: !If [ CreateLambdaZipsBucket, !Ref LambdaZipsBucket, !Ref LambdaZipsBucketName ]
       SourceBucket: !Ref 'QSS3BucketName'
       Prefix: !Ref 'QSS3KeyPrefix'
       Objects:
@@ -135,7 +135,7 @@ Resources:
       Runtime: python2.7
       Timeout: 900
       Code:
-        S3Bucket: !Ref LambdaZipsBucketName
+        S3Bucket: !If [ CreateLambdaZipsBucket, !Ref LambdaZipsBucket, !Ref LambdaZipsBucketName ]
         S3Key: !Sub '${QSS3KeyPrefix}functions/packages/LambdaEniCleanup/lambda.zip'
   HelmLambda:
     DependsOn: CopyZips
@@ -147,7 +147,7 @@ Resources:
       Runtime: python3.6
       Timeout: 900
       Code:
-        S3Bucket: !Ref LambdaZipsBucketName
+        S3Bucket: !If [ CreateLambdaZipsBucket, !Ref LambdaZipsBucket, !Ref LambdaZipsBucketName ]
         S3Key: !Sub '${QSS3KeyPrefix}functions/packages/Helm/lambda.zip'
       VpcConfig:
         SecurityGroupIds: [ !Ref EKSLambdaSecurityGroup ]
@@ -162,7 +162,7 @@ Resources:
       Runtime: python3.6
       Timeout: 900
       Code:
-        S3Bucket: !Ref LambdaZipsBucketName
+        S3Bucket: !If [ CreateLambdaZipsBucket, !Ref LambdaZipsBucket, !Ref LambdaZipsBucketName ]
         S3Key: !Sub '${QSS3KeyPrefix}functions/packages/KubeManifest/lambda.zip'
       VpcConfig:
         SecurityGroupIds: [ !Ref EKSLambdaSecurityGroup ]
@@ -177,7 +177,7 @@ Resources:
       Runtime: python3.6
       Timeout: 900
       Code:
-        S3Bucket: !Ref LambdaZipsBucketName
+        S3Bucket: !If [ CreateLambdaZipsBucket, !Ref LambdaZipsBucket, !Ref LambdaZipsBucketName ]
         S3Key: !Sub '${QSS3KeyPrefix}functions/packages/KubeGet/lambda.zip'
       VpcConfig:
         SecurityGroupIds: [ !Ref EKSLambdaSecurityGroup ]
@@ -192,7 +192,7 @@ Resources:
       Runtime: python2.7
       Timeout: 900
       Code:
-        S3Bucket: !Ref LambdaZipsBucketName
+        S3Bucket: !If [ CreateLambdaZipsBucket, !Ref LambdaZipsBucket, !Ref LambdaZipsBucketName ]
         S3Key: !Sub '${QSS3KeyPrefix}functions/packages/DeleteBucketContents/lambda.zip'
   CopyZipsFunction:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
# Issue #10

OPTIONAL parameter `LambdaZipsBucketName` used unconditionally throughout _cloudbees-core-existing-cluster.template.yaml_

When tying to deploy to an existing EKS cluster using template _cloudbees-core-existing-cluster.template.yaml_ the OPTIONAL parameter `LambdaZipsBucketName` is used unconditionally in `Custom::CopyZips` and all `AWS::Lambda::Function` resources.

While condition `CreateLambdaZipsBucket` based on presence of `LambdaZipsBucketName` is effectively used to create an S3 bucket, this bucket is never actually used.

# Description of changes

Following the same pattern found in _amazon-eks.template.yaml_ from *quickstart-amazon-eks*, use condition `CreateLambdaZipsBucket` to determine whether or not to use the provided `LambdaZipsBucketName` of the name of the S3 bucket created by the template.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
