### PR TITLE
fix: add mappings for K8s 1.13

### DIFF
--- a/templates/cloudbees-core-spot-nodes.template.yaml
+++ b/templates/cloudbees-core-spot-nodes.template.yaml
@@ -434,18 +434,20 @@ Parameters:
     Type: String
   KubernetesVersion: 
     Type: String
+    AllowedValues: [ "1.13", "1.12", "1.11" ]
+    Default: "1.13"
   
 Mappings:
   K8sVersionMap:
+    "1.13":
+      STD: AMZNEKS113
+      GPU: AMZNEKS113GPU
     "1.12":
       STD: AMZNEKS112
       GPU: AMZNEKS112GPU
     "1.11":
       STD: AMZNEKS111
       GPU: AMZNEKS111GPU
-    "1.10":
-      STD: AMZNEKS110
-      GPU: AMZNEKS110GPU
   InstanceTypes:
     t2.small: { Type: STD }
     t2.medium: { Type: STD }
@@ -543,103 +545,103 @@ Mappings:
     z1d.12xlarge: { Type: STD }
   AWSAMIRegionMap:
     AMI:
-      AMZNEKS110: amazon-eks-node-1.10-v20
-      AMZNEKS110GPU: amazon-eks-gpu-node-1.10-v20
       AMZNEKS111: amazon-eks-node-1.11-v20
       AMZNEKS111GPU: amazon-eks-gpu-node-1.11-v20
       AMZNEKS112: amazon-eks-node-1.12-v20
       AMZNEKS112GPU: amazon-eks-gpu-node-1.12-v20
+      AMZNEKS113: amazon-eks-node-1.13-v20
+      AMZNEKS113GPU: amazon-eks-gpu-node-1.13-v20
     ap-northeast-1:
-      AMZNEKS110: ami-0c9fb6a3fda95d373
-      AMZNEKS110GPU: ami-073f06a1edd22ae2e
-      AMZNEKS111: ami-0d555d5f56c843803
-      AMZNEKS111GPU: ami-07fc636e8f6d3e18b
-      AMZNEKS112: ami-0bfedee6a7845c26d
-      AMZNEKS112GPU: ami-08e41cc84f4b3f27f
+      AMZNEKS113: ami-0fde798d17145fae1
+      AMZNEKS113GPU: ami-04cf69bbd6c0fae0b
+      AMZNEKS111: ami-0a0b6606652f9b3b9
+      AMZNEKS111GPU: ami-0a8f4e1f9bf09a81f
+      AMZNEKS112: ami-0a9b3f8b4b65b402b
+      AMZNEKS112GPU: ami-0cd09d7293f31df8a
     ap-northeast-2:
-      AMZNEKS110: ami-00ea4ea959f28b4cf
-      AMZNEKS110GPU: ami-0baff950f5217e54e
-      AMZNEKS111: ami-0144ae839b1111571
-      AMZNEKS111GPU: ami-002057772097fcef9
-      AMZNEKS112: ami-0a904348b703e620c
-      AMZNEKS112GPU: ami-0c43b885e33fdc29e
+      AMZNEKS113: ami-07fd7609df6c8e39b
+      AMZNEKS113GPU: ami-0730e699ed0118737
+      AMZNEKS111: ami-0c84b3f055cda1afb
+      AMZNEKS111GPU: ami-01db6bb089f6adfcf
+      AMZNEKS112: ami-069f6a654a8795f72
+      AMZNEKS112GPU: ami-006549812c03748cb
     ap-south-1:
-      AMZNEKS110: ami-0f07478f5c5eb9e20
-      AMZNEKS110GPU: ami-033bd2c2a3431923e
-      AMZNEKS111: ami-02071c0110dc365ba
-      AMZNEKS111GPU: ami-04fe7f4c75aac7196
-      AMZNEKS112: ami-09c3eb35bb3be46a4
-      AMZNEKS112GPU: ami-0d3ecaf4f3318c714
+      AMZNEKS113: ami-0a9b1c1807b1a40ab
+      AMZNEKS113GPU: ami-005b754faac73f0cc
+      AMZNEKS111: ami-00f1adebe5ab9a431
+      AMZNEKS111GPU: ami-04645af6384529c5d
+      AMZNEKS112: ami-01b6a163133c31994
+      AMZNEKS112GPU: ami-09ad3a49fb13389a0
     ap-southeast-1:
-      AMZNEKS110: ami-05dac5d0ada75e22f
-      AMZNEKS110GPU: ami-09defa93988984fa1
-      AMZNEKS111: ami-00c91afdb73cf7f93
-      AMZNEKS111GPU: ami-08d5da0b12751a31f
-      AMZNEKS112: ami-07b922b9b94d9a6d2
-      AMZNEKS112GPU: ami-0655b4dbbe2d46703
+      AMZNEKS113: ami-0361e14efd56a71c7
+      AMZNEKS113GPU: ami-07be5e97a529cd146
+      AMZNEKS111: ami-05e92412054db3f87
+      AMZNEKS111GPU: ami-0e001196bd450aa0c
+      AMZNEKS112: ami-03737a1ac334a5767
+      AMZNEKS112GPU: ami-01be8fddd9b16320c
     ap-southeast-2:
-      AMZNEKS110: ami-00513f18e1900ce1e
-      AMZNEKS110GPU: ami-00d9364d705e902c9
-      AMZNEKS111: ami-05f4510fcfe56961c
-      AMZNEKS111GPU: ami-04024dd8e0b9e36ff
-      AMZNEKS112: ami-0f0121e9e64ebd3dc
-      AMZNEKS112GPU: ami-07079cd9ff1b312da
+      AMZNEKS113: ami-0237d87bc27daba65
+      AMZNEKS113GPU: ami-0a2f4c3aeb596aa7e
+      AMZNEKS111: ami-07eb76498b1ba6cd6
+      AMZNEKS111GPU: ami-0c7132a332aa55aa6
+      AMZNEKS112: ami-07580768e8538626f
+      AMZNEKS112GPU: ami-0a1bf783357dd8492
     eu-central-1:
-      AMZNEKS110: ami-03bdf8079f6c013c5
-      AMZNEKS110GPU: ami-0a8536a894bd4ea06
-      AMZNEKS111: ami-0c2709025eb548246
-      AMZNEKS111GPU: ami-0bf09c13f4204ce9d
-      AMZNEKS112: ami-0d741ed58ca5b342e
-      AMZNEKS112GPU: ami-0c57db5b204001099
+      AMZNEKS113: ami-0b7127e7a2a38802a
+      AMZNEKS113GPU: ami-0fbbd205f797ecccd
+      AMZNEKS111: ami-0234bc9c2b341aa02
+      AMZNEKS111GPU: ami-05cb4f6e8be8b83f1
+      AMZNEKS112: ami-0ee5ca4231511cafc
+      AMZNEKS112GPU: ami-0ae5976723472b6d4
     eu-north-1:
-      AMZNEKS110: ami-0be77fe86d741fc81
-      AMZNEKS110GPU: ami-05baf7a6c293fe2ed
-      AMZNEKS111: ami-084bd3569d08c6e67
-      AMZNEKS111GPU: ami-0a1714bb5be631b59
-      AMZNEKS112: ami-0c65a309fc58f6907
-      AMZNEKS112GPU: ami-09354b076296f5946
+      AMZNEKS113: ami-0fd05922165907b85
+      AMZNEKS113GPU: ami-0641def7f02a4cac5
+      AMZNEKS111: ami-02ebf24da505128f9
+      AMZNEKS111GPU: ami-078c260b9a737fc35
+      AMZNEKS112: ami-03e60b5a990893129
+      AMZNEKS112GPU: ami-0122b7e2a6736e3c5
     eu-west-1:
-      AMZNEKS110: ami-06368da7f495b68e9
-      AMZNEKS110GPU: ami-0f6f3929a9d7a418e
-      AMZNEKS111: ami-0e82e73403dd69fa3
-      AMZNEKS111GPU: ami-0b4d0f56587640d5a
-      AMZNEKS112: ami-08716b70cac884aaa
-      AMZNEKS112GPU: ami-0fbc930681258db86
+      AMZNEKS113: ami-00ac2e6b3cb38a9b9
+      AMZNEKS113GPU: ami-0f9571a3e65dc4e20
+      AMZNEKS111: ami-06902949103360023
+      AMZNEKS111GPU: ami-02f337476a5c33f1b
+      AMZNEKS112: ami-0404d23c7e8188740
+      AMZNEKS112GPU: ami-042f9abf2f96a0097
     eu-west-2:
-      AMZNEKS110: ami-0f1f2189b4741bc60
-      AMZNEKS110GPU: ami-0a12396b818bc2383
-      AMZNEKS111: ami-0da9aa88dd2ec8297
-      AMZNEKS111GPU: ami-00e98f9e6fd2319e5
-      AMZNEKS112: ami-0c7388116d474ee10
-      AMZNEKS112GPU: ami-0d832fced2cfe0f7b
+      AMZNEKS113: ami-0147919d2ff9a6ad5
+      AMZNEKS113GPU: ami-032348bd69c5dd665
+      AMZNEKS111: ami-0db100ad46c7966d2
+      AMZNEKS111GPU: ami-0aa2208dbb9bb7cc5
+      AMZNEKS112: ami-07346d8553f83f9d6
+      AMZNEKS112GPU: ami-0b87e9246afd42760
     eu-west-3:
-      AMZNEKS110: ami-03a9acb0f6e0d424d
-      AMZNEKS110GPU: ami-086d5edcaacd0ccfd
-      AMZNEKS111: ami-099369bc73d1cc66f
-      AMZNEKS111GPU: ami-0039e2556e6290828
-      AMZNEKS112: ami-0560aea042fec8b12
-      AMZNEKS112GPU: ami-0f8fa088b406ebba2
+      AMZNEKS113: ami-0537ee9329c1628a2
+      AMZNEKS113GPU: ami-053962359d6859fec
+      AMZNEKS111: ami-052046d313576d0ba
+      AMZNEKS111GPU: ami-0f6ea479cb4e7a4d2
+      AMZNEKS112: ami-038cb36289174bac4
+      AMZNEKS112GPU: ami-0d9405868a6e9ee11
     us-east-1:
-      AMZNEKS110: ami-03a1e71fb42fc37dd
-      AMZNEKS110GPU: ami-00f74c3728d4ca27d
-      AMZNEKS111: ami-02c1de421df89c58d
-      AMZNEKS111GPU: ami-06ec2ea207616c078
-      AMZNEKS112: ami-0abcb9f9190e867ab
-      AMZNEKS112GPU: ami-0cb7959f92429410a
+      AMZNEKS113: ami-0f2e8e5663e16b436
+      AMZNEKS113GPU: ami-0017d945a10387606
+      AMZNEKS111: ami-0a5f5d5b0f6f58199
+      AMZNEKS111GPU: ami-07207754196c1a8fc
+      AMZNEKS112: ami-0e380e0a62d368837
+      AMZNEKS112GPU: ami-06e46a15650294dfa
     us-east-2:
-      AMZNEKS110: ami-093d55c2ba99ab2c8
-      AMZNEKS110GPU: ami-0a788defb66cdfffb
-      AMZNEKS111: ami-03b1b6cc34c010f9c
-      AMZNEKS111GPU: ami-0e6993a35aae3407b
-      AMZNEKS112: ami-04ea7cb66af82ae4a
-      AMZNEKS112GPU: ami-0118b61dc2312dee2
+      AMZNEKS113: ami-0485258c2d1c3608f
+      AMZNEKS113GPU: ami-0ccac9d9b57864000
+      AMZNEKS111: ami-03c6648b74285020f
+      AMZNEKS111GPU: ami-0b87186dda80931ee
+      AMZNEKS112: ami-0fe61ae4c397e710d
+      AMZNEKS112GPU: ami-067d88fb64d3d7990
     us-west-2:
-      AMZNEKS110: ami-05a71d034119ffc12
-      AMZNEKS110GPU: ami-0901518d7557125c8
-      AMZNEKS111: ami-05ecac759c81e0b0c
-      AMZNEKS111GPU: ami-08377056d89909b2a
-      AMZNEKS112: ami-0923e4b35a30a5f53
-      AMZNEKS112GPU: ami-0bebf2322fd52a42e
+      AMZNEKS113: ami-03a55127c613349a7
+      AMZNEKS113GPU: ami-08335952e837d087b
+      AMZNEKS111: ami-057d1c0dcb254a878
+      AMZNEKS111GPU: ami-052da6a4e0ae156ad
+      AMZNEKS112: ami-0355c210cb3f58aa2
+      AMZNEKS112GPU: ami-084e8e620163aa50e
 
 Resources:
   NodeSecurityGroup:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-quickstart/quickstart-cloudbees-core/issues/14

*Description of changes:*
* A regression was introduced in https://github.com/aws-quickstart/quickstart-cloudbees-core/pull/9 - I failed to add AMI mappings. Sorry about that.
* EOL for Kubernetes 1.10

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
