### PR TITLE
Hotfix for a submodule update

### DIFF
--- a/templates/cloudbees-core-addl-nodes.template.yaml
+++ b/templates/cloudbees-core-addl-nodes.template.yaml
@@ -541,6 +541,8 @@ Parameters:
     Type: String
   NodeInstanceRoleName:
     Type: String
+  NodeInstanceRoleArn:
+    Type: String
   KubernetesVersion: 
     Type: String
   QSS3BucketName:
@@ -592,6 +594,7 @@ Resources:
         ControlPlaneSecurityGroup: !Ref ControlPlaneSecurityGroup
         NodeInstanceProfile: !Ref NodeInstanceProfile
         NodeInstanceRoleName: !Ref NodeInstanceRoleName
+        NodeInstanceRoleArn: !Ref NodeInstanceRoleArn
         KubernetesVersion: !Ref KubernetesVersion
         BootstrapArguments: "--kubelet-extra-args '--node-labels=partition=regular-agents --register-with-taints=partition=regular-agents:NoSchedule'"
   SpotAgentNodesStack:

--- a/templates/cloudbees-core-existing-vpc.template.yaml
+++ b/templates/cloudbees-core-existing-vpc.template.yaml
@@ -923,6 +923,7 @@ Resources:
         BastionSecurityGroup: !GetAtt EKSStack.Outputs.BastionSecurityGroup
         NodeInstanceProfile: !GetAtt EKSStack.Outputs.NodeInstanceProfile
         NodeInstanceRoleName: !GetAtt EKSStack.Outputs.NodeInstanceRoleName
+        NodeInstanceRoleArn: !GetAtt EKSStack.Outputs.NodeInstanceRoleArn
         KubernetesVersion: !Ref KubernetesVersion
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix


### PR DESCRIPTION
https://github.com/cloudbees/quickstart-cloudbees-core/commit/18a870983f9097442e3891fc8210e86cfd7b6fef got mixed with our release branch (`develop`) and broke the build.

Simple fix: make sure `NodeInstanceRoleArn` is passed to the nodegroup template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
