### PR TITLE
April 2020 Release

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -9,17 +9,10 @@ project:
   - us-west-2
   - eu-west-1
   parameters:
-    AvailabilityZones: $[taskcat_genaz_3]
-    CustomValueYaml: ''
-    KeyPairName: override
-    KubernetesVersion: '1.14'
-    NumberOfMasterNodes: '2'
-    NumberOfRegularNodes: '1'
-    NumberOfSpotNodes: '1'
+    RemoteAccessCIDR: 10.0.0.0/16
     QSS3BucketName: $[taskcat_autobucket]
     QSS3BucketRegion: $[taskcat_current_region]
-    RemoteAccessCIDR: 10.0.0.0/16
-    StorageClassName: aws-efs
+    AvailabilityZones: $[taskcat_genaz_3]
   template: templates/cloudbees-core-master.template.yaml
 tests:
   default:

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -8,6 +8,7 @@ project:
   - us-east-2
   - us-west-2
   - eu-west-1
+  - ca-central-1
   parameters:
     RemoteAccessCIDR: 10.0.0.0/16
     QSS3BucketName: $[taskcat_autobucket]

--- a/templates/cloudbees-core-addl-nodes.template.yaml
+++ b/templates/cloudbees-core-addl-nodes.template.yaml
@@ -17,9 +17,11 @@ Parameters:
   PrivateSubnet1ID:
     Type: "AWS::EC2::Subnet::Id"
   PrivateSubnet2ID:
-    Type: "AWS::EC2::Subnet::Id"
+    Type: String
+    Default: ""
   PrivateSubnet3ID:
-    Type: "AWS::EC2::Subnet::Id"
+    Type: String
+    Default: ""
   RegularNodeInstanceType:
     Default: m5.large
     AllowedValues:

--- a/templates/cloudbees-core-addl-nodes.template.yaml
+++ b/templates/cloudbees-core-addl-nodes.template.yaml
@@ -1,6 +1,12 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Deploys additional node pools to an EKS Quick Start cluster (qs-1pipqrqef)
 
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+      - W2507 # BastionSecurityGroup is intentionally a String instead of AWS::EC2::SecurityGroup::Id
+
 Parameters:
   KeyPairName:
     Description: The name of an existing public/private key pair, which allows you
@@ -536,7 +542,7 @@ Parameters:
   InitialNodeGroupSecurityGroup:
     Type: AWS::EC2::SecurityGroup::Id
   BastionSecurityGroup:
-    Type: AWS::EC2::SecurityGroup::Id
+    Type: String
   NodeInstanceProfile: 
     Type: String
   NodeInstanceRoleName:
@@ -571,6 +577,7 @@ Parameters:
     Type: String
 Conditions:
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
+  UsingBastion: !Not [!Equals [!Ref 'BastionSecurityGroup', '']]
 Resources:
   RegularAgentNodesStack:
     Type: "AWS::CloudFormation::Stack"
@@ -624,6 +631,7 @@ Resources:
         KubernetesVersion: !Ref KubernetesVersion
   #Allow the bastion host to SSH into the additional node pools
   BastionToRegularIngress:
+    Condition: UsingBastion
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow SSH from Bastion server to Regular Nodes
@@ -633,6 +641,7 @@ Resources:
       ToPort: 22
       FromPort: 22
   BastionToSpotIngress:
+    Condition: UsingBastion
     Type: "AWS::EC2::SecurityGroupIngress"
     Properties:
       Description: Allow SSH from Bastion server to Spot Nodes

--- a/templates/cloudbees-core-efs.template.yaml
+++ b/templates/cloudbees-core-efs.template.yaml
@@ -4,9 +4,7 @@ Description: Deploys an EFS file system and efs-provisioner (qs-1pipqrqhi)
 Parameters:
   HelmLambdaArn:
     Type: String
-  KubeConfigPath:
-    Type: String
-  KubeConfigKmsContext:
+  ClusterName:
     Type: String
   InitialNodeGroupSecurityGroup:
     Type: AWS::EC2::SecurityGroup::Id
@@ -53,8 +51,7 @@ Resources:
     Version: '1.0'
     Properties:
       ServiceToken: !Ref HelmLambdaArn
-      KubeConfigPath: !Ref KubeConfigPath
-      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      ClusterName: !Ref ClusterName
       Chart: stable/efs-provisioner
       Name: efs-provisioner
       Namespace: efs-provisioner

--- a/templates/cloudbees-core-efs.template.yaml
+++ b/templates/cloudbees-core-efs.template.yaml
@@ -13,9 +13,17 @@ Parameters:
   PrivateSubnet1ID:
     Type: AWS::EC2::Subnet::Id
   PrivateSubnet2ID:
-    Type: AWS::EC2::Subnet::Id
+    Type: String
+    Default: ""
   PrivateSubnet3ID:
-    Type: AWS::EC2::Subnet::Id
+    Type: String
+    Default: ""
+
+Conditions:
+  3AZDeployment: !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
+  2AZDeployment: !Or
+    - !Not [!Equals [!Ref PrivateSubnet2ID, ""]]
+    - !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
 
 Resources:
   EFSFileSystem:
@@ -35,12 +43,14 @@ Resources:
       SecurityGroups: [ !Ref InitialNodeGroupSecurityGroup ]
       SubnetId: !Ref PrivateSubnet1ID
   MountTargetPrivateSubnet2:
+    Condition: 2AZDeployment
     Type: AWS::EFS::MountTarget
     Properties:
       FileSystemId: !Ref EFSFileSystem
       SecurityGroups: [ !Ref InitialNodeGroupSecurityGroup ]
       SubnetId: !Ref PrivateSubnet2ID
   MountTargetPrivateSubnet3:
+    Condition: 3AZDeployment
     Type: AWS::EFS::MountTarget
     Properties:
       FileSystemId: !Ref EFSFileSystem

--- a/templates/cloudbees-core-existing-vpc.template.yaml
+++ b/templates/cloudbees-core-existing-vpc.template.yaml
@@ -9,8 +9,8 @@ Metadata:
         Parameters:
           - KeyPairName
           - RemoteAccessCIDR
-          - AdditionalEKSAdminArns
-          - KubeConfigKmsContext
+          - AdditionalEKSAdminUserArn
+          - AdditionalEKSAdminRoleArn
       - Label:
           default: Network configuration
         Parameters:
@@ -21,6 +21,9 @@ Metadata:
           - PublicSubnet1ID
           - PublicSubnet2ID
           - PublicSubnet3ID
+          - EKSPublicAccessCIDRs
+          - EKSPublicAccessEndpoint
+          - EKSPrivateAccessEndpoint
       - Label:
           default: CloudBees Core configuration
         Parameters:
@@ -52,10 +55,10 @@ Metadata:
         default: SSH key name
       RemoteAccessCIDR:
         default: Remote access CIDR
-      AdditionalEKSAdminArns:
-        default: Additional EKS admin ARNs
-      KubeConfigKmsContext:
-        default: Kubernetes config KMS context
+      AdditionalEKSAdminUserArn:
+        default: Additional EKS admin ARN (IAM user)
+      AdditionalEKSAdminRoleArn:
+        default: Additional EKS admin ARN (IAM role)
       VPCID:
         default: VPC ID
       PrivateSubnet1ID:
@@ -70,6 +73,12 @@ Metadata:
         default: Public subnet 2 ID
       PublicSubnet3ID:
         default: Public subnet 3 ID
+      EKSPublicAccessCIDRs:
+        default: EKS public access CIDRs
+      EKSPublicAccessEndpoint:
+        default: EKS public access endpoint
+      EKSPrivateAccessEndpoint:
+        default: EKS private access endpoint
       MasterNodeInstanceType:
         default: Master nodes instance type
       RegularNodeInstanceType:
@@ -122,14 +131,14 @@ Parameters:
       that you set this value to a trusted IP range. Setting this parameter to 0.0.0.0/0 
       will open SSH access to the bastion host from any source address.
     Type: String
-  AdditionalEKSAdminArns:
+  AdditionalEKSAdminUserArn:
     Default: ""
-    Description: "[OPTIONAL] Comma-separated list of IAM users/roles to be granted admin access to the EKS cluster"
-    Type: CommaDelimitedList
-  KubeConfigKmsContext:
-    Description: String value used by KMS to encrypt/decrypt Kubernetes config
+    Description: "[OPTIONAL] IAM user Amazon Resource Name (ARN) to be granted admin access to the EKS cluster"
     Type: String
-    Default: "CloudBeesCore"
+  AdditionalEKSAdminRoleArn:
+    Default: ""
+    Description: "[OPTIONAL] IAM role Amazon Resource Name (ARN) to be granted admin access to the EKS cluster"
+    Type: String
   VPCID:
     Description: ID of your existing VPC for deployment
     Type: AWS::EC2::VPC::Id
@@ -157,6 +166,24 @@ Parameters:
     Description: ID of public subnet 3 in Availability Zone 3 for the ELB load balancer
       (e.g., subnet-5e26bac2)
     Type: AWS::EC2::Subnet::Id
+  EKSPublicAccessCIDRs:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    Description: The public CIDR IP ranges that are permitted to access the Kubernetes API. These values are only used
+      if EKSPublicAccessEndpoint is enabled. Can't contain private IP ranges.
+    Type: List<String>
+    Default: 0.0.0.0/0
+  EKSPublicAccessEndpoint:
+    Type: String
+    AllowedValues: [Enabled, Disabled]
+    Default: Disabled
+    Description: Configure access to the Kubernetes API server endpoint from outside of your VPC.
+  EKSPrivateAccessEndpoint:
+    Type: String
+    AllowedValues: [Enabled, Disabled]
+    Default: Enabled
+    Description: Configure access to the Kubernetes API server endpoint from within your VPC. If this is disabled,
+      EKSPublicAccessEndpoint must be enabled.
   MasterNodeInstanceType:
     Default: r5.xlarge
     AllowedValues:
@@ -875,7 +902,8 @@ Resources:
       Parameters:
         KeyPairName: !Ref KeyPairName
         RemoteAccessCIDR: !Ref RemoteAccessCIDR
-        AdditionalEKSAdminArns: !Join [ ",", !Ref AdditionalEKSAdminArns ]
+        AdditionalEKSAdminUserArn: !Ref AdditionalEKSAdminUserArn
+        AdditionalEKSAdminRoleArn: !Ref AdditionalEKSAdminRoleArn
         VPCID: !Ref VPCID
         PrivateSubnet1ID: !Ref PrivateSubnet1ID
         PrivateSubnet2ID: !Ref PrivateSubnet2ID
@@ -883,13 +911,15 @@ Resources:
         PublicSubnet1ID: !Ref PublicSubnet1ID
         PublicSubnet2ID: !Ref PublicSubnet2ID
         PublicSubnet3ID: !Ref PublicSubnet3ID
+        EKSPublicAccessCIDRs: !Join [ ',', !Ref 'EKSPublicAccessCIDRs' ]
+        EKSPublicAccessEndpoint: !Ref EKSPublicAccessEndpoint
+        EKSPrivateAccessEndpoint: !Ref EKSPrivateAccessEndpoint
         KubernetesVersion: !Ref KubernetesVersion
         NodeInstanceType: !Ref MasterNodeInstanceType
         NumberOfNodes: !Ref NumberOfMasterNodes
         NodeGroupName: "cloudbees-core-masters"
         NodeVolumeSize: !Ref MasterNodeVolumeSize
         CustomAmiId: !Ref CustomAmiId
-        KubeConfigKmsContext: !Ref KubeConfigKmsContext
         BootstrapArguments: "--kubelet-extra-args '--node-labels=partition=masters'"
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Sub "${QSS3KeyPrefix}submodules/quickstart-amazon-eks/"
@@ -938,8 +968,7 @@ Resources:
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         HelmLambdaArn: !GetAtt EKSStack.Outputs.HelmLambdaArn
-        KubeConfigPath: !GetAtt EKSStack.Outputs.KubeConfigPath
-        KubeConfigKmsContext: !Ref KubeConfigKmsContext
+        ClusterName: !GetAtt EKSStack.Outputs.EKSClusterName
         InitialNodeGroupSecurityGroup: !GetAtt EKSStack.Outputs.NodeGroupSecurityGroup
         PrivateSubnet1ID: !Ref PrivateSubnet1ID
         PrivateSubnet2ID: !Ref PrivateSubnet2ID
@@ -953,11 +982,9 @@ Resources:
         - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
           S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
-        #KubeManifestLambdaArn: !GetAtt EKSStack.Outputs.KubeManifestLambdaArn
         KubeGetLambdaArn: !GetAtt EKSStack.Outputs.KubeGetLambdaArn
         HelmLambdaArn: !GetAtt EKSStack.Outputs.HelmLambdaArn
-        KubeConfigPath: !GetAtt EKSStack.Outputs.KubeConfigPath
-        KubeConfigKmsContext: !Ref KubeConfigKmsContext
+        ClusterName: !GetAtt EKSStack.Outputs.EKSClusterName
         StorageClassName: !Ref StorageClassName
         CustomValueYaml: !Ref CustomValueYaml
 
@@ -968,6 +995,3 @@ Outputs:
   BastionIP:
     Value: !GetAtt EKSStack.Outputs.BastionIP
     Description: Bastion host IP address. Log in (via SSH) to retrieve the initial admin password and administer CloudBees Core.
-  KubeConfigPath:
-    Value: !GetAtt EKSStack.Outputs.KubeConfigPath
-    Description: (Advanced) Amazon S3 bucket containing encrypted Kubernetes config which can be used to access the Kubernetes API.

--- a/templates/cloudbees-core-existing-vpc.template.yaml
+++ b/templates/cloudbees-core-existing-vpc.template.yaml
@@ -145,27 +145,33 @@ Parameters:
   PrivateSubnet1ID:
     Description: ID of private subnet 1 in Availability Zone 1 for the Workload (e.g.,
       subnet-a0246dcd)
-    Type: AWS::EC2::Subnet::Id
+    Type: String
+    Default: ""
   PrivateSubnet2ID:
     Description: ID of private subnet 2 in Availability Zone 2 for the Workload (e.g.,
       subnet-b1f432cd)
-    Type: AWS::EC2::Subnet::Id
+    Type: String
+    Default: ""
   PrivateSubnet3ID:
     Description: ID of private subnet 3 in Availability Zone 3 for the Workload (e.g.,
       subnet-b1f4a2cd)
-    Type: AWS::EC2::Subnet::Id
+    Type: String
+    Default: ""
   PublicSubnet1ID:
     Description: ID of public subnet 1 in Availability Zone 1 for the ELB load balancer
       (e.g., subnet-9bc642ac)
-    Type: AWS::EC2::Subnet::Id
+    Type: String
+    Default: ""
   PublicSubnet2ID:
     Description: ID of public subnet 2 in Availability Zone 2 for the ELB load balancer
       (e.g., subnet-e3246d8e)
-    Type: AWS::EC2::Subnet::Id
+    Type: String
+    Default: ""
   PublicSubnet3ID:
     Description: ID of public subnet 3 in Availability Zone 3 for the ELB load balancer
       (e.g., subnet-5e26bac2)
-    Type: AWS::EC2::Subnet::Id
+    Type: String
+    Default: ""
   EKSPublicAccessCIDRs:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
@@ -886,11 +892,17 @@ Rules:
              - ap-northeast-1
              - ap-northeast-2
              - ap-south-1
+             - ca-central-1
           - !Ref 'AWS::Region'
 
 Conditions:
+  3AZDeployment: !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
+  2AZDeployment: !Or
+    - !Not [!Equals [!Ref PrivateSubnet2ID, ""]]
+    - !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
   EFSCondition: !Equals [!Ref 'StorageClassName', 'aws-efs']
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
+
 Resources:
   EKSStack:
     Type: AWS::CloudFormation::Stack
@@ -905,12 +917,24 @@ Resources:
         AdditionalEKSAdminUserArn: !Ref AdditionalEKSAdminUserArn
         AdditionalEKSAdminRoleArn: !Ref AdditionalEKSAdminRoleArn
         VPCID: !Ref VPCID
-        PrivateSubnet1ID: !Ref PrivateSubnet1ID
-        PrivateSubnet2ID: !Ref PrivateSubnet2ID
-        PrivateSubnet3ID: !Ref PrivateSubnet3ID
         PublicSubnet1ID: !Ref PublicSubnet1ID
-        PublicSubnet2ID: !Ref PublicSubnet2ID
-        PublicSubnet3ID: !Ref PublicSubnet3ID
+        PublicSubnet2ID: !If
+          - 2AZDeployment
+          - !Ref PublicSubnet2ID
+          - !Ref AWS::NoValue
+        PublicSubnet3ID: !If
+          - 3AZDeployment
+          - !Ref PublicSubnet3ID
+          - !Ref AWS::NoValue
+        PrivateSubnet1ID: !Ref PrivateSubnet1ID
+        PrivateSubnet2ID: !If
+          - 2AZDeployment
+          - !Ref PrivateSubnet2ID
+          - !Ref AWS::NoValue
+        PrivateSubnet3ID: !If
+          - 3AZDeployment
+          - !Ref PrivateSubnet3ID
+          - !Ref AWS::NoValue
         EKSPublicAccessCIDRs: !Join [ ',', !Ref 'EKSPublicAccessCIDRs' ]
         EKSPublicAccessEndpoint: !Ref EKSPublicAccessEndpoint
         EKSPrivateAccessEndpoint: !Ref EKSPrivateAccessEndpoint

--- a/templates/cloudbees-core-master.template.yaml
+++ b/templates/cloudbees-core-master.template.yaml
@@ -9,8 +9,8 @@ Metadata:
         Parameters:
           - KeyPairName
           - RemoteAccessCIDR
-          - AdditionalEKSAdminArns
-          - KubeConfigKmsContext
+          - AdditionalEKSAdminUserArn
+          - AdditionalEKSAdminRoleArn
       - Label:
           default: Network configuration
         Parameters:
@@ -22,6 +22,9 @@ Metadata:
           - PublicSubnet1CIDR
           - PublicSubnet2CIDR
           - PublicSubnet3CIDR
+          - EKSPublicAccessCIDRs
+          - EKSPublicAccessEndpoint
+          - EKSPrivateAccessEndpoint
       - Label:
           default: CloudBees Core configuration
         Parameters:
@@ -53,10 +56,10 @@ Metadata:
         default: SSH key name
       RemoteAccessCIDR:
         default: Remote access CIDR
-      AdditionalEKSAdminArns:
-        default: Additional EKS admin ARNs
-      KubeConfigKmsContext:
-        default: Kubernetes config KMS context
+      AdditionalEKSAdminUserArn:
+        default: Additional EKS admin ARN (IAM user)
+      AdditionalEKSAdminRoleArn:
+        default: Additional EKS admin ARN (IAM role)
       AvailabilityZones:
         default: Availability Zones
       VPCCIDR:
@@ -73,6 +76,12 @@ Metadata:
         default: Public subnet 2 CIDR
       PublicSubnet3CIDR:
         default: Public subnet 3 CIDR
+      EKSPublicAccessCIDRs:
+        default: EKS public access CIDRs
+      EKSPublicAccessEndpoint:
+        default: EKS public access endpoint
+      EKSPrivateAccessEndpoint:
+        default: EKS private access endpoint
       MasterNodeInstanceType:
         default: Master nodes instance type
       RegularNodeInstanceType:
@@ -126,14 +135,14 @@ Parameters:
       that you set this value to a trusted IP range. Setting this parameter to 0.0.0.0/0 
       will open SSH access to the bastion host from any source address.
     Type: String
-  AdditionalEKSAdminArns:
+  AdditionalEKSAdminUserArn:
     Default: ""
-    Description: "[OPTIONAL] Comma-separated list of IAM users/roles to be granted admin access to the EKS cluster"
-    Type: CommaDelimitedList
-  KubeConfigKmsContext:
-    Description: String value used by KMS to encrypt/decrypt Kubernetes config
+    Description: "[OPTIONAL] IAM user Amazon Resource Name (ARN) to be granted admin access to the EKS cluster"
     Type: String
-    Default: "CloudBeesCore"
+  AdditionalEKSAdminRoleArn:
+    Default: ""
+    Description: "[OPTIONAL] IAM role Amazon Resource Name (ARN) to be granted admin access to the EKS cluster"
+    Type: String
   AvailabilityZones:
     Description:
       List of Availability Zones to use for the subnets in the VPC. Three
@@ -184,6 +193,24 @@ Parameters:
     Default: 10.0.160.0/20
     Description: CIDR block for the public (DMZ) subnet 3 located in Availability Zone 3
     Type: String
+  EKSPublicAccessCIDRs:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    Description: The public CIDR IP ranges that are permitted to access the Kubernetes API. These values are only used
+      if EKSPublicAccessEndpoint is enabled. Can't contain private IP ranges.
+    Type: List<String>
+    Default: 0.0.0.0/0
+  EKSPublicAccessEndpoint:
+    Type: String
+    AllowedValues: [Enabled, Disabled]
+    Default: Disabled
+    Description: Configure access to the Kubernetes API server endpoint from outside of your VPC.
+  EKSPrivateAccessEndpoint:
+    Type: String
+    AllowedValues: [Enabled, Disabled]
+    Default: Enabled
+    Description: Configure access to the Kubernetes API server endpoint from within your VPC. If this is disabled,
+      EKSPublicAccessEndpoint must be enabled.
   MasterNodeInstanceType:
     Default: r5.xlarge
     AllowedValues:
@@ -922,8 +949,8 @@ Resources:
       Parameters:
         KeyPairName: !Ref KeyPairName
         RemoteAccessCIDR: !Ref RemoteAccessCIDR
-        AdditionalEKSAdminArns: !Join [ ",", !Ref AdditionalEKSAdminArns ]
-        KubeConfigKmsContext: !Ref KubeConfigKmsContext
+        AdditionalEKSAdminUserArn: !Ref AdditionalEKSAdminUserArn
+        AdditionalEKSAdminRoleArn: !Ref AdditionalEKSAdminRoleArn
         VPCID: !GetAtt 'VPCStack.Outputs.VPCID'
         PrivateSubnet1ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet1AID'
         PrivateSubnet2ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet2AID'
@@ -931,6 +958,9 @@ Resources:
         PublicSubnet1ID: !GetAtt 'VPCStack.Outputs.PublicSubnet1ID'
         PublicSubnet2ID: !GetAtt 'VPCStack.Outputs.PublicSubnet2ID'
         PublicSubnet3ID: !GetAtt 'VPCStack.Outputs.PublicSubnet3ID'
+        EKSPublicAccessCIDRs: !Join [ ',', !Ref 'EKSPublicAccessCIDRs' ]
+        EKSPublicAccessEndpoint: !Ref EKSPublicAccessEndpoint
+        EKSPrivateAccessEndpoint: !Ref EKSPrivateAccessEndpoint
         KubernetesVersion: !Ref KubernetesVersion
         StorageClassName: !Ref StorageClassName
         ProvisionedThroughputInMibps: !Ref ProvisionedThroughputInMibps
@@ -959,6 +989,3 @@ Outputs:
   BastionIP:
     Value: !GetAtt CloudBeesCoreExistingVPCStack.Outputs.BastionIP
     Description: Bastion host IP address. Log in (via SSH) to retrieve the initial admin password and administer CloudBees Core.
-  KubeConfigPath:
-    Value: !GetAtt CloudBeesCoreExistingVPCStack.Outputs.KubeConfigPath
-    Description: (Advanced) Amazon S3 bucket containing encrypted Kubernetes config which can be used to access the Kubernetes API.

--- a/templates/cloudbees-core-master.template.yaml
+++ b/templates/cloudbees-core-master.template.yaml
@@ -14,6 +14,7 @@ Metadata:
       - Label:
           default: Network configuration
         Parameters:
+          - NumberOfAZs
           - AvailabilityZones
           - VPCCIDR
           - PrivateSubnet1CIDR
@@ -60,6 +61,8 @@ Metadata:
         default: Additional EKS admin ARN (IAM user)
       AdditionalEKSAdminRoleArn:
         default: Additional EKS admin ARN (IAM role)
+      NumberOfAZs:
+        default: Number of Availability Zones
       AvailabilityZones:
         default: Availability Zones
       VPCCIDR:
@@ -143,6 +146,11 @@ Parameters:
     Default: ""
     Description: "[OPTIONAL] IAM role Amazon Resource Name (ARN) to be granted admin access to the EKS cluster"
     Type: String
+  NumberOfAZs:
+    Type: String
+    AllowedValues: ["2", "3"]
+    Default: "3"
+    Description: Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter.
   AvailabilityZones:
     Description:
       List of Availability Zones to use for the subnets in the VPC. Three
@@ -915,8 +923,13 @@ Rules:
              - ap-northeast-1
              - ap-northeast-2
              - ap-south-1
+             - ca-central-1
           - !Ref 'AWS::Region'
 Conditions:
+  3AZDeployment: !Equals [!Ref NumberOfAZs, "3"]
+  2AZDeployment: !Or
+    - !Equals [!Ref NumberOfAZs, "2"]
+    - !Equals [!Ref NumberOfAZs, "3"]
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, 'aws-quickstart']
 Resources:
   VPCStack:
@@ -929,7 +942,7 @@ Resources:
       Parameters:
         KeyPairName: !Ref KeyPairName
         AvailabilityZones: !Join [",", !Ref AvailabilityZones]
-        NumberOfAZs: '3'
+        NumberOfAZs: !Ref 'NumberOfAZs'
         VPCCIDR: !Ref VPCCIDR
         PrivateSubnet1ACIDR: !Ref 'PrivateSubnet1CIDR'
         PrivateSubnet2ACIDR: !Ref 'PrivateSubnet2CIDR'
@@ -952,12 +965,24 @@ Resources:
         AdditionalEKSAdminUserArn: !Ref AdditionalEKSAdminUserArn
         AdditionalEKSAdminRoleArn: !Ref AdditionalEKSAdminRoleArn
         VPCID: !GetAtt 'VPCStack.Outputs.VPCID'
-        PrivateSubnet1ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet1AID'
-        PrivateSubnet2ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet2AID'
-        PrivateSubnet3ID: !GetAtt 'VPCStack.Outputs.PrivateSubnet3AID'
-        PublicSubnet1ID: !GetAtt 'VPCStack.Outputs.PublicSubnet1ID'
-        PublicSubnet2ID: !GetAtt 'VPCStack.Outputs.PublicSubnet2ID'
-        PublicSubnet3ID: !GetAtt 'VPCStack.Outputs.PublicSubnet3ID'
+        PublicSubnet1ID: !GetAtt VPCStack.Outputs.PublicSubnet1ID
+        PublicSubnet2ID: !If
+          - 2AZDeployment
+          - !GetAtt VPCStack.Outputs.PublicSubnet2ID
+          - !Ref AWS::NoValue
+        PublicSubnet3ID: !If
+          - 3AZDeployment
+          - !GetAtt VPCStack.Outputs.PublicSubnet3ID
+          - !Ref AWS::NoValue
+        PrivateSubnet1ID: !GetAtt VPCStack.Outputs.PrivateSubnet1AID
+        PrivateSubnet2ID: !If
+          - 2AZDeployment
+          - !GetAtt VPCStack.Outputs.PrivateSubnet2AID
+          - !Ref AWS::NoValue
+        PrivateSubnet3ID: !If
+          - 3AZDeployment
+          - !GetAtt VPCStack.Outputs.PrivateSubnet3AID
+          - !Ref AWS::NoValue
         EKSPublicAccessCIDRs: !Join [ ',', !Ref 'EKSPublicAccessCIDRs' ]
         EKSPublicAccessEndpoint: !Ref EKSPublicAccessEndpoint
         EKSPrivateAccessEndpoint: !Ref EKSPrivateAccessEndpoint

--- a/templates/cloudbees-core-spot-nodes.template.yaml
+++ b/templates/cloudbees-core-spot-nodes.template.yaml
@@ -32,9 +32,11 @@ Parameters:
   PrivateSubnet1ID:
     Type: "AWS::EC2::Subnet::Id"
   PrivateSubnet2ID:
-    Type: "AWS::EC2::Subnet::Id"
+    Type: String
+    Default: ""
   PrivateSubnet3ID:
-    Type: "AWS::EC2::Subnet::Id"
+    Type: String
+    Default: ""
   SpotNodeInstanceType1:
     Default: m4.large #2x8
     AllowedValues:
@@ -461,6 +463,10 @@ Parameters:
     Default: "1.15"
   
 Conditions:
+  3AZDeployment: !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
+  2AZDeployment: !Or
+    - !Not [!Equals [!Ref PrivateSubnet2ID, ""]]
+    - !Not [!Equals [!Ref PrivateSubnet3ID, ""]]
   IsSingleInstance: !Equals
     - !Ref NumberOfNodes
     - 1
@@ -747,7 +753,13 @@ Resources:
       - Key: !Sub 'k8s.io/cluster-autoscaler/${EKSControlPlane}'
         Value: ''
         PropagateAtLaunch: true
-      VPCZoneIdentifier: [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID, !Ref PrivateSubnet3ID ]
+      VPCZoneIdentifier: !If
+        - 3AZDeployment
+        - [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID, !Ref PrivateSubnet3ID ]
+        - !If
+          - 2AZDeployment
+          - [ !Ref PrivateSubnet1ID, !Ref PrivateSubnet2ID ]
+          - [ !Ref PrivateSubnet1ID ]
       MixedInstancesPolicy: 
         LaunchTemplate:
           LaunchTemplateSpecification:

--- a/templates/cloudbees-core-workload.template.yaml
+++ b/templates/cloudbees-core-workload.template.yaml
@@ -2,15 +2,11 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Deploys CloudBees Core into an existing Kubernetes cluster (qs-1pipqrqje)
 
 Parameters:
-  # KubeManifestLambdaArn:
-  #   Type: String
   KubeGetLambdaArn:
     Type: String
   HelmLambdaArn:
     Type: String
-  KubeConfigPath:
-    Type: String
-  KubeConfigKmsContext:
+  ClusterName:
     Type: String
   StorageClassName:
     Type: String
@@ -23,11 +19,10 @@ Resources:
     Version: '1.0'
     Properties:
       ServiceToken: !Ref HelmLambdaArn
-      KubeConfigPath: !Ref KubeConfigPath
-      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      ClusterName: !Ref ClusterName
       RepoUrl: https://charts.cloudbees.com/public/cloudbees
       Chart: cloudbees/cloudbees-core
-      Version: 3.12.0+80c17a044bc4
+      Version: 3.13.0+899a413a0e8f
       Name: cloudbees-core
       Namespace: cloudbees-core
       ValueYaml: !Sub |
@@ -60,8 +55,7 @@ Resources:
     Version: '1.0'
     Properties:
       ServiceToken: !Ref KubeGetLambdaArn
-      KubeConfigPath: !Ref KubeConfigPath
-      KubeConfigKmsContext: !Ref KubeConfigKmsContext
+      ClusterName: !Ref ClusterName
       Namespace: cloudbees-core
       Name: 'svc/cloudbees-core-nginx-ingress-controller'
       JsonPath: '{.status.loadBalancer.ingress[0].hostname}'
@@ -69,4 +63,3 @@ Resources:
 Outputs:
   CloudBeesJenkinsOperationsCenterUrl:
     Value: !Sub "http://${IngressHostName}/cjoc"
-  #InitialAdminPassword: requires `Custom::KubeExec` or similar


### PR DESCRIPTION
*Summary of changes:*
* Add support for two zone network architecture
  * Canada Central (`ca-central-1`) added as a supported region
  * Amazon built another datacenter: https://aws.amazon.com/about-aws/whats-new/2020/03/aws-canada-central-region-adds-third-availability-zone/ 🤷‍♂️ 
* Add support for private subnet only network architecture, with internal ELB
  * Example custom values file: https://github.com/schottsfired/my-custom-values/blob/internal-elb/customValues.yaml
* Delete `AdditionalEksAdminArns` parameter, replace with `AdditionalEKSAdminUserArn` and `AdditionalEKSAdminRoleArn` parameters*
* Add `EKSPublicAccessCIDRs`, `EKSPublicAccessEndpoint`, and `EKSPrivateAccessEndpoint` parameters for toggling public/private EKS control plane
* Minor CI changes - rely on defaults instead of supplying values
* Latest CloudBees Core version: 2.222.2.1
  * Release notes: https://docs.cloudbees.com/docs/release-notes/latest/cloudbees-core/modern-cloud-platforms/2.222.2.1

(*) indicates a breaking change, where user intervention may be required during an upgrade.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
